### PR TITLE
Use correct pg_config for Debian package build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ OBJS = pgmemcache.o
 DATA_built = $(MODULE_big).sql
 SHLIB_LINK = -lmemcached -lsasl2
 
-PGXS := $(shell pg_config --pgxs)
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 
 # Build a release tarball. To make a release, update PGMC_VERSION, adjust

--- a/debian/packages.in
+++ b/debian/packages.in
@@ -8,9 +8,9 @@ Description: libmemcached interface for PostgreSQL
 Copyright: .
  Copyright 2010 Hannu Valtonen
 Build: sh
- make
+ make PG_CONFIG=/usr/lib/postgresql/PGVER/bin/pg_config
 Clean: sh
- make clean || true
+ make clean PG_CONFIG=/usr/lib/postgresql/PGVER/bin/pg_config || true
 Build-Depends: postgresql-server-dev-PGVER, flex | flex-old, bison, yada, libmemcached-dev, libpq-dev, devscripts, libsasl2-dev
 
 
@@ -23,6 +23,6 @@ Depends: []
 Description: memcached client functions for PostgreSQL
  .
 Install: sh
- make install DESTDIR=$ROOT
+ make install PG_CONFIG=/usr/lib/postgresql/PGVER/bin/pg_config DESTDIR=$ROOT
 
 


### PR DESCRIPTION
Before, it would use whatever pg_config was in the path, which was not
necessarily the one that belonged to the PostgreSQL major version for
which the package was meant to be built.  That could result in broken
or invalid packages.

Fix that by allowing overriding the pg_config location via a make
variable, and make the yada setup use this.
