### PR TITLE
pgmemcache: fix arguments and return types in guc functions.

### DIFF
--- a/pgmemcache.h
+++ b/pgmemcache.h
@@ -40,16 +40,13 @@ void _PG_init(void);
 void _PG_fini(void);
 
 /* Custom GUC variable */
-static GucStringAssignHook assign_default_servers_guc(const char *newval, bool doit, GucSource source);
-static GucStringAssignHook assign_default_behavior_guc (const char *newval, bool doit, GucSource source);
-static GucStringAssignHook assign_default_behavior (const char *newval);
-static GucShowHook show_default_servers_guc (void);
-static GucShowHook show_default_behavior_guc (void);
-static GucShowHook show_memcache_sasl_authentication_username_guc (void);
-static GucShowHook show_memcache_sasl_authentication_password_guc (void);
-#if defined(PG_VERSION_NUM) && (PG_VERSION_NUM >= 90100)
-static GucStringCheckHook check_default_guc(const char *newval, void **extra, GucSource source);
-#endif
+static void assign_default_servers_guc(const char *newval, void *extra);
+static void assign_default_behavior_guc (const char *newval, void *extra);
+static void assign_default_behavior (const char *newval);
+static const char *show_default_servers_guc (void);
+static const char *show_default_behavior_guc (void);
+static const char *show_memcache_sasl_authentication_username_guc (void);
+static const char *show_memcache_sasl_authentication_password_guc (void);
 static memcached_behavior get_memcached_behavior_flag (const char *flag);
 static uint64_t get_memcached_behavior_data (const char *flag, const char *data);
 static uint64_t get_memcached_hash_type (const char *data);


### PR DESCRIPTION
Also removed the custom default value check function which was not supposed
to do anything, but sometimes returned false values to the caller as the
function is supposed to return a boolean value (1 byte) but returned a
pointer instead.
