### PR TITLE
pgmemcache: correct free function for memcached_stat_get_value

### DIFF
--- a/pgmemcache.c
+++ b/pgmemcache.c
@@ -818,7 +818,7 @@ static memcached_return_t server_stat_function(memcached_st *ptr,
     {
       char *value = memcached_stat_get_value(ptr, &stat, *stat_ptr, &rc);
       appendStringInfo(context, "%s: %s\n", *stat_ptr, value);
-      pfree(value);
+      libmc_stat_free(value);
     }
 
   pfree(list);

--- a/pgmemcache.h
+++ b/pgmemcache.h
@@ -36,6 +36,13 @@
 #undef PACKAGE_TARNAME
 #undef PACKAGE_VERSION
 
+/* libmemcached 1.0.16 changed the allocation function for values returned from memcached_stat_get_value */
+#if LIBMEMCACHED_VERSION_HEX >= 0x01000016
+  #define libmc_stat_free free
+#else
+  #define libmc_stat_free pfree
+#endif
+
 void _PG_init(void);
 void _PG_fini(void);
 


### PR DESCRIPTION
libmemcached 1.0.16 and greater switched to using malloc for
values returned from memcached_stat_get_value.
