### PR TITLE
Use pg_regress for make installcheck testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ DATA =	ext/pgmemcache--unpackaged--2.0.sql \
 	ext/pgmemcache--2.0--2.1.sql \
 	ext/pgmemcache--2.1--2.1.1.sql \
 	ext/pgmemcache--2.1.1--2.1.2.sql
+REGRESS = init start_memcached test stop_memcached
 
 SHLIB_LINK = -lmemcached -lsasl2
 

--- a/expected/init.out
+++ b/expected/init.out
@@ -1,0 +1,1 @@
+CREATE EXTENSION pgmemcache;

--- a/expected/start_memcached.out
+++ b/expected/start_memcached.out
@@ -1,0 +1,2 @@
+\! service memcached start
+Starting memcached: memcached.

--- a/expected/stop_memcached.out
+++ b/expected/stop_memcached.out
@@ -1,0 +1,2 @@
+\! service memcached stop
+Stopping memcached: memcached.

--- a/expected/test.out
+++ b/expected/test.out
@@ -1,0 +1,69 @@
+\i test.sql
+SELECT memcache_server_add('localhost');
+ memcache_server_add 
+---------------------
+ t
+(1 row)
+
+SELECT regexp_replace(memcache_stats(), 'pid:.*', '') AS memcache_stats;
+      memcache_stats       
+---------------------------
+                          +
+ Server: localhost (11211)+
+ 
+(1 row)
+
+SELECT memcache_delete('jeah');
+ memcache_delete 
+-----------------
+ f
+(1 row)
+
+SELECT memcache_set('jeah','test_value1');
+ memcache_set 
+--------------
+ t
+(1 row)
+
+SELECT memcache_add('counter','10');
+ memcache_add 
+--------------
+ t
+(1 row)
+
+SELECT memcache_incr('counter', 30);
+ memcache_incr 
+---------------
+            40
+(1 row)
+
+SELECT memcache_get('counter');
+ memcache_get 
+--------------
+ 40
+(1 row)
+
+SELECT memcache_decr('counter');
+ memcache_decr 
+---------------
+            39
+(1 row)
+
+SELECT memcache_delete('counter');
+ memcache_delete 
+-----------------
+ t
+(1 row)
+
+SELECT memcache_get('counter');
+ memcache_get 
+--------------
+ 
+(1 row)
+
+SELECT memcache_get('jeah');
+ memcache_get 
+--------------
+ test_value1
+(1 row)
+

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION pgmemcache;

--- a/sql/start_memcached.sql
+++ b/sql/start_memcached.sql
@@ -1,0 +1,1 @@
+\! service memcached start

--- a/sql/stop_memcached.sql
+++ b/sql/stop_memcached.sql
@@ -1,0 +1,1 @@
+\! service memcached stop

--- a/sql/test.sql
+++ b/sql/test.sql
@@ -1,0 +1,1 @@
+\i test.sql

--- a/test.sql
+++ b/test.sql
@@ -1,5 +1,5 @@
 SELECT memcache_server_add('localhost');
-SELECT memcache_stats();
+SELECT regexp_replace(memcache_stats(), 'pid:.*', '') AS memcache_stats;
 SELECT memcache_delete('jeah');
 SELECT memcache_set('jeah','test_value1');
 SELECT memcache_add('counter','10');


### PR DESCRIPTION
This uses pg_regress to start a memcached instance, run test queries
from test.sql, and stops the memcached again. Needs root.

apt.postgresql.org uses this for integration testing for the Debian
packages; these tests discovered the incompatibility with libmemcached
1.0.16.
