### PR TITLE
Perfomance

### DIFF
--- a/pgmemcache.c
+++ b/pgmemcache.c
@@ -415,7 +415,8 @@ Datum memcache_get(PG_FUNCTION_ARGS)
 
   get_key = PG_GETARG_TEXT_P(0);
 
-  key = DatumGetCString(DirectFunctionCall1(textout, PointerGetDatum(get_key)));
+  //key = DatumGetCString(DirectFunctionCall1(textout, PointerGetDatum(get_key)));
+  key = VARDATA(get_key);
   key_length = strlen(key);
 
   if (key_length < 1)


### PR DESCRIPTION
Please explain, why you use DatumGetCString(DirectFunctionCall1(textout, PointerGetDatum(get_key))) to covert to char*. It is a lot of useless conversations. All we need is to get the pointer to char data, simply use VARDATA macros, Example, https://github.com/winlibs/postgresql/blob/master/src/backend/utils/adt/quote.c#L89  
If I left something behind - give me to know.
