### PR TITLE
pgmemcache: support building with omcache instead of libmemcached

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,13 @@ DATA =	ext/pgmemcache--unpackaged--2.0.sql \
 	ext/pgmemcache--2.1.2--2.2.0.sql
 REGRESS = init start_memcached test stop_memcached
 
+ifeq ($(USE_OMCACHE),1)
+SHLIB_LINK = -lomcache
+PG_CPPFLAGS += -DUSE_OMCACHE
+else
 SHLIB_LINK = -lmemcached -lsasl2
+PG_CPPFLAGS += -DUSE_LIBMEMCACHED
+endif
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/pgmemcache.h
+++ b/pgmemcache.h
@@ -13,7 +13,6 @@
 #ifndef PGMEMCACHE_H
 #define PGMEMCACHE_H
 
-#include <libmemcached/memcached.h>
 #include "postgres.h"
 #include <inttypes.h>
 #include "access/heapam.h"


### PR DESCRIPTION
Support for a new memcache client library, OMcache, in addition to
libmemcached which remains the default.  To build with OMcache install the
OMcache development packages and build with 'make USE_OMCACHE=1'.

See https://github.com/saaros/omcache for more information about OMcache.
